### PR TITLE
feat(cid): calculate the CID for decoded and newly created Tokeners

### DIFF
--- a/delegation/delegation.go
+++ b/delegation/delegation.go
@@ -1,4 +1,13 @@
+// Package delegation implements the UCAN [delegation] specification with
+// an immutable Token type as well as methods to convert the Token to and
+// from the [envelope]-enclosed, signed and DAG-CBOR-encoded form that
+// should most commonly be used for transport and storage.
+//
+// [delegation]: https://github.com/ucan-wg/delegation/tree/v1_ipld
+// [envelope]: https://github.com/ucan-wg/spec#envelope
 package delegation
+
+// TODO: change the "delegation" link above when the specification is merged
 
 import (
 	"crypto/rand"
@@ -15,6 +24,7 @@ import (
 	"github.com/ucan-wg/go-ucan/pkg/meta"
 )
 
+// Token is an immutable type that holds the fields of a UCAN delegation.
 type Token struct {
 	// Issuer DID (sender)
 	issuer did.DID
@@ -162,6 +172,8 @@ func (t *Token) validate() error {
 	return errs
 }
 
+// Option is a type that allows optional fields to be set during the
+// creation of a Token.
 type Option func(*Token) error
 
 // WithExpiration set's the Token's optional "expiration" field to the
@@ -179,6 +191,7 @@ func WithExpiration(exp time.Time) Option {
 }
 
 // WithMeta adds a key/value pair in the "meta" field.
+//
 // WithMeta can be used multiple times in the same call.
 // Accepted types for the value are: bool, string, int, int32, int64, []byte,
 // and ipld.Node.

--- a/delegation/delegation_test.go
+++ b/delegation/delegation_test.go
@@ -1,12 +1,10 @@
 package delegation_test
 
 import (
-	"crypto/rand"
 	"testing"
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/crypto"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gotest.tools/v3/golden"
 
@@ -14,7 +12,6 @@ import (
 	"github.com/ucan-wg/go-ucan/capability/policy"
 	"github.com/ucan-wg/go-ucan/delegation"
 	"github.com/ucan-wg/go-ucan/did"
-	"github.com/ucan-wg/go-ucan/internal/envelope"
 )
 
 const (
@@ -91,7 +88,7 @@ func TestConstructors(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("New", func(t *testing.T) {
-		dlg, err := delegation.New(privKey, aud, cmd, pol,
+		tkn, err := delegation.New(privKey, aud, cmd, pol,
 			delegation.WithNonce([]byte(nonce)),
 			delegation.WithSubject(sub),
 			delegation.WithExpiration(exp),
@@ -100,19 +97,18 @@ func TestConstructors(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		data, err := dlg.ToDagJson(privKey)
+		data, err := tkn.ToDagJson(privKey)
 		require.NoError(t, err)
 
 		t.Log(string(data))
 
 		golden.Assert(t, string(data), "new.dagjson")
-		assert.Equal(t, newCID, envelope.CIDToBase58BTC(dlg.CID()))
 	})
 
 	t.Run("Root", func(t *testing.T) {
 		t.Parallel()
 
-		dlg, err := delegation.Root(privKey, aud, cmd, pol,
+		tkn, err := delegation.Root(privKey, aud, cmd, pol,
 			delegation.WithNonce([]byte(nonce)),
 			delegation.WithExpiration(exp),
 			delegation.WithMeta("foo", "fooo"),
@@ -120,13 +116,12 @@ func TestConstructors(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		data, err := dlg.ToDagJson(privKey)
+		data, err := tkn.ToDagJson(privKey)
 		require.NoError(t, err)
 
 		t.Log(string(data))
 
 		golden.Assert(t, string(data), "root.dagjson")
-		assert.Equal(t, rootCID, envelope.CIDToBase58BTC(dlg.CID()))
 	})
 }
 
@@ -140,24 +135,4 @@ func privKey(t *testing.T, privKeyCfg string) crypto.PrivKey {
 	require.NoError(t, err)
 
 	return privKey
-}
-
-func TestKey(t *testing.T) {
-	// TODO: why is this broken?
-	t.Skip("TODO: why is this broken?")
-
-	priv, _, err := crypto.GenerateEd25519Key(rand.Reader)
-	require.NoError(t, err)
-
-	privMar, err := crypto.MarshalPrivateKey(priv)
-	require.NoError(t, err)
-
-	privCfg := crypto.ConfigEncodeKey(privMar)
-	t.Log(privCfg)
-
-	id, err := did.FromPubKey(priv.GetPublic())
-	require.NoError(t, err)
-	t.Log(id)
-
-	t.Fail()
 }

--- a/delegation/delegation_test.go
+++ b/delegation/delegation_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gotest.tools/v3/golden"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/ucan-wg/go-ucan/capability/policy"
 	"github.com/ucan-wg/go-ucan/delegation"
 	"github.com/ucan-wg/go-ucan/did"
+	"github.com/ucan-wg/go-ucan/internal/envelope"
 )
 
 const (
@@ -64,6 +66,9 @@ const (
 	]
 ]
 `
+
+	newCID  = "zdpuAn9JgGPvnt2WCmTaKktZdbuvcVGTg9bUT5kQaufwUtZ6e"
+	rootCID = "zdpuAkgGmUp5JrXvehGuuw9JA8DLQKDaxtK3R8brDQQVC2i5X"
 )
 
 func TestConstructors(t *testing.T) {
@@ -101,6 +106,7 @@ func TestConstructors(t *testing.T) {
 		t.Log(string(data))
 
 		golden.Assert(t, string(data), "new.dagjson")
+		assert.Equal(t, newCID, envelope.CIDToBase58BTC(dlg.CID()))
 	})
 
 	t.Run("Root", func(t *testing.T) {
@@ -120,6 +126,7 @@ func TestConstructors(t *testing.T) {
 		t.Log(string(data))
 
 		golden.Assert(t, string(data), "root.dagjson")
+		assert.Equal(t, rootCID, envelope.CIDToBase58BTC(dlg.CID()))
 	})
 }
 

--- a/delegation/ipld.go
+++ b/delegation/ipld.go
@@ -15,10 +15,10 @@ import (
 	"github.com/ucan-wg/go-ucan/internal/envelope"
 )
 
-// Seal wraps the delegation token in an envelope, generates the signature,
-// encodes the result to DAG-CBOR and calculates the CID of the resulting
-// binary data.
-func (t *Token) Seal(privKey crypto.PrivKey) ([]byte, cid.Cid, error) {
+// ToSealed wraps the delegation token in an envelope, generates the
+// signature, encodes the result to DAG-CBOR and calculates the CID of
+// the resulting binary data.
+func (t *Token) ToSealed(privKey crypto.PrivKey) ([]byte, cid.Cid, error) {
 	data, err := t.ToDagCbor(privKey)
 	if err != nil {
 		return nil, cid.Undef, err
@@ -32,8 +32,8 @@ func (t *Token) Seal(privKey crypto.PrivKey) ([]byte, cid.Cid, error) {
 	return data, id, nil
 }
 
-// SealWriter is the same as Seal but accepts an io.Writer.
-func (t *Token) SealWriter(w io.Writer, privKey crypto.PrivKey) (cid.Cid, error) {
+// ToSealedWriter is the same as Seal but accepts an io.Writer.
+func (t *Token) ToSealedWriter(w io.Writer, privKey crypto.PrivKey) (cid.Cid, error) {
 	cidWriter := envelope.NewCIDWriter(w)
 
 	if err := t.ToDagCborWriter(cidWriter, privKey); err != nil {
@@ -43,11 +43,11 @@ func (t *Token) SealWriter(w io.Writer, privKey crypto.PrivKey) (cid.Cid, error)
 	return cidWriter.CID()
 }
 
-// Unseal decodes the provided binary data from the DAG-CBOR format,
+// FromSealed decodes the provided binary data from the DAG-CBOR format,
 // verifies that the envelope's signature is correct based on the public
 // key taken from the issuer (iss) field and calculates the CID of the
 // incoming data.
-func Unseal(data []byte) (*Token, error) {
+func FromSealed(data []byte) (*Token, error) {
 	tkn, err := FromDagCbor(data)
 	if err != nil {
 		return nil, err
@@ -63,8 +63,8 @@ func Unseal(data []byte) (*Token, error) {
 	return tkn, nil
 }
 
-// UnsealReader is the same as Unseal but accepts an io.Reader.
-func UnsealReader(r io.Reader) (*Token, error) {
+// FromSealedReader is the same as Unseal but accepts an io.Reader.
+func FromSealedReader(r io.Reader) (*Token, error) {
 	cidReader := envelope.NewCIDReader(r)
 
 	tkn, err := FromDagCborReader(cidReader)

--- a/delegation/schema.go
+++ b/delegation/schema.go
@@ -14,7 +14,13 @@ import (
 	"github.com/ucan-wg/go-ucan/pkg/meta"
 )
 
+// [Tag] is the string used as a key within the SigPayload that identifies
+// that the TokenPayload is a delegation.
+//
+// [Tag]: https://github.com/ucan-wg/delegation/tree/v1_ipld#type-tag
 const Tag = "ucan/dlg@1.0.0-rc.1"
+
+// TODO: update the above Tag URL once the delegation specification is merged.
 
 //go:embed delegation.ipldsch
 var schemaBytes []byte

--- a/delegation/schema_test.go
+++ b/delegation/schema_test.go
@@ -1,11 +1,13 @@
 package delegation_test
 
 import (
+	"bytes"
 	_ "embed"
 	"fmt"
 	"testing"
 
 	"github.com/ipld/go-ipld-prime"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gotest.tools/v3/golden"
 
@@ -22,29 +24,62 @@ func TestSchemaRoundTrip(t *testing.T) {
 	delegationJson := golden.Get(t, "new.dagjson")
 	privKey := privKey(t, issuerPrivKeyCfg)
 
-	// format:    dagJson   -->   PayloadModel   -->   dagCbor   -->   PayloadModel   -->   dagJson
-	// function:      DecodeDagJson()      EncodeDagCbor()   DecodeDagCbor()     EncodeDagJson()
+	t.Run("via buffers", func(t *testing.T) {
+		t.Parallel()
 
-	p1, id1, err := delegation.FromDagJson([]byte(delegationJson))
-	require.NoError(t, err)
-	require.Equal(t, newCID, envelope.CIDToBase58BTC(id1))
+		// format:    dagJson   -->   PayloadModel   -->   dagCbor   -->   PayloadModel   -->   dagJson
+		// function:      DecodeDagJson()           Seal()        Unseal()          EncodeDagJson()
 
-	cborBytes, err := p1.ToDagCbor(privKey)
-	require.NoError(t, err)
-	fmt.Println("cborBytes length", len(cborBytes))
-	fmt.Println("cbor", string(cborBytes))
+		p1, err := delegation.FromDagJson([]byte(delegationJson))
+		require.NoError(t, err)
 
-	p2, id2, err := delegation.FromDagCbor(cborBytes)
-	require.NoError(t, err)
-	fmt.Println("read Cbor", p2)
+		cborBytes, id, err := p1.Seal(privKey)
+		require.NoError(t, err)
+		assert.Equal(t, newCID, envelope.CIDToBase58BTC(id))
+		fmt.Println("cborBytes length", len(cborBytes))
+		fmt.Println("cbor", string(cborBytes))
 
-	readJson, err := p2.ToDagJson(privKey)
-	require.NoError(t, err)
-	require.Equal(t, newCID, envelope.CIDToBase58BTC(id2))
-	fmt.Println("readJson length", len(readJson))
-	fmt.Println("json: ", string(readJson))
+		p2, err := delegation.Unseal(cborBytes)
+		require.NoError(t, err)
+		assert.Equal(t, id, p2.CID())
+		fmt.Println("read Cbor", p2)
 
-	require.JSONEq(t, string(delegationJson), string(readJson))
+		readJson, err := p2.ToDagJson(privKey)
+		require.NoError(t, err)
+		fmt.Println("readJson length", len(readJson))
+		fmt.Println("json: ", string(readJson))
+
+		assert.JSONEq(t, string(delegationJson), string(readJson))
+	})
+
+	t.Run("via streaming", func(t *testing.T) {
+		t.Parallel()
+
+		buf := bytes.NewBuffer(delegationJson)
+
+		// format:    dagJson   -->   PayloadModel   -->   dagCbor   -->   PayloadModel   -->   dagJson
+		// function:      DecodeDagJson()           Seal()         Unseal()         EncodeDagJson()
+
+		p1, err := delegation.FromDagJsonReader(buf)
+		require.NoError(t, err)
+
+		cborBytes := &bytes.Buffer{}
+		id, err := p1.SealWriter(cborBytes, privKey)
+		t.Log(len(id.Bytes()), id.Bytes())
+		require.NoError(t, err)
+		assert.Equal(t, newCID, envelope.CIDToBase58BTC(id))
+
+		// buf = bytes.NewBuffer(cborBytes.Bytes())
+		p2, err := delegation.UnsealReader(cborBytes)
+		require.NoError(t, err)
+		t.Log(len(p2.CID().Bytes()), p2.CID().Bytes())
+		assert.Equal(t, envelope.CIDToBase58BTC(id), envelope.CIDToBase58BTC(p2.CID()))
+
+		readJson := &bytes.Buffer{}
+		require.NoError(t, p2.ToDagJsonWriter(readJson, privKey))
+
+		assert.JSONEq(t, string(delegationJson), readJson.String())
+	})
 }
 
 func BenchmarkSchemaLoad(b *testing.B) {

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/libp2p/go-libp2p v0.36.3
 	github.com/multiformats/go-multibase v0.2.0
 	github.com/multiformats/go-multicodec v0.9.0
+	github.com/multiformats/go-multihash v0.2.3
 	github.com/multiformats/go-varint v0.0.7
 	github.com/stretchr/testify v1.9.0
 	gotest.tools/v3 v3.5.1
@@ -24,7 +25,6 @@ require (
 	github.com/mr-tron/base58 v1.2.0 // indirect
 	github.com/multiformats/go-base32 v0.1.0 // indirect
 	github.com/multiformats/go-base36 v0.2.0 // indirect
-	github.com/multiformats/go-multihash v0.2.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/polydawn/refmt v0.89.0 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect

--- a/internal/envelope/cid.go
+++ b/internal/envelope/cid.go
@@ -1,9 +1,11 @@
 package envelope
 
 import (
+	"crypto/sha256"
+	"hash"
+	"io"
+
 	"github.com/ipfs/go-cid"
-	"github.com/ipld/go-ipld-prime"
-	"github.com/ipld/go-ipld-prime/codec/dagcbor"
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/multiformats/go-multibase"
 	"github.com/multiformats/go-multicodec"
@@ -38,12 +40,89 @@ func CIDFromBytes(b []byte) (cid.Cid, error) {
 	}.Sum(b)
 }
 
-// CIDFromIPLD returns the UCAN content identifier for an ipld.Node.
-func CIDFromIPLD(node ipld.Node) (cid.Cid, error) {
-	data, err := ipld.Encode(node, dagcbor.Encode)
-	if err != nil {
-		return cid.Undef, nil
+var _ io.Reader = (*CIDReader)(nil)
+
+// CIDReader wraps an io.Reader and includes a hash.Hash that is updated
+// as data is read from the child io.Reader.
+type CIDReader struct {
+	hash hash.Hash
+	r    io.Reader
+	err  error
+}
+
+// NewCIDReader initializes a hash.Hash to calculate the CID's hash and
+// and returns a wrapped io.Reader.
+func NewCIDReader(r io.Reader) *CIDReader {
+	hash := sha256.New()
+	hash.Reset()
+
+	return &CIDReader{
+		hash: hash,
+		r:    r,
+	}
+}
+
+// CID returns the UCAN-formatted cid.Cid created from the hash calculated
+// as bytes are read from the inner io.Reader.
+func (r *CIDReader) CID() (cid.Cid, error) {
+	if r.err != nil {
+		return cid.Undef, r.err // TODO: Wrap to say it's an error during streaming?
 	}
 
-	return CIDFromBytes(data)
+	return cidFromHash(r.hash)
+}
+
+// Read implements io.Reader.
+func (r *CIDReader) Read(p []byte) (n int, err error) {
+	n, err = r.r.Read(p)
+	if err != nil && err != io.EOF {
+		r.err = err
+
+		return
+	}
+
+	_, _ = r.hash.Write(p[:n])
+
+	return
+}
+
+var _ io.Writer = (*CIDWriter)(nil)
+
+type CIDWriter struct {
+	hash hash.Hash
+	w    io.Writer
+	err  error
+}
+
+func NewCIDWriter(w io.Writer) *CIDWriter {
+	hash := sha256.New()
+	hash.Reset()
+
+	return &CIDWriter{
+		hash: hash,
+		w:    w,
+	}
+}
+
+func (w *CIDWriter) CID() (cid.Cid, error) {
+	return cidFromHash(w.hash)
+}
+
+func (w *CIDWriter) Write(p []byte) (n int, err error) {
+	if _, err = w.hash.Write(p); err != nil {
+		w.err = err
+
+		return
+	}
+
+	return w.w.Write(p)
+}
+
+func cidFromHash(hash hash.Hash) (cid.Cid, error) {
+	mh, err := multihash.Encode(hash.Sum(nil), multihash.SHA2_256)
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	return cid.NewCidV1(uint64(multicodec.DagCbor), mh), nil
 }

--- a/internal/envelope/cid.go
+++ b/internal/envelope/cid.go
@@ -1,0 +1,49 @@
+package envelope
+
+import (
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/codec/dagcbor"
+	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/multiformats/go-multibase"
+	"github.com/multiformats/go-multicodec"
+	"github.com/multiformats/go-multihash"
+)
+
+var b58BTCEnc = multibase.MustNewEncoder(multibase.Base58BTC)
+
+// CIDToBase56BTC is a utility method to convert a CIDv1 to the canonical
+// string representation used by UCAN.
+func CIDToBase58BTC(id cid.Cid) string {
+	return id.Encode(b58BTCEnc)
+}
+
+// CID returns the UCAN content identifier a Tokener.
+func CID(privKey crypto.PrivKey, token Tokener) (cid.Cid, error) {
+	data, err := ToDagCbor(privKey, token)
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	return CIDFromBytes(data)
+}
+
+// CIDFromBytes returns the UCAN content identifier for an arbitrary slice
+// of bytes.
+func CIDFromBytes(b []byte) (cid.Cid, error) {
+	return cid.V1Builder{
+		Codec:    uint64(multicodec.DagCbor),
+		MhType:   multihash.SHA2_256,
+		MhLength: 0,
+	}.Sum(b)
+}
+
+// CIDFromIPLD returns the UCAN content identifier for an ipld.Node.
+func CIDFromIPLD(node ipld.Node) (cid.Cid, error) {
+	data, err := ipld.Encode(node, dagcbor.Encode)
+	if err != nil {
+		return cid.Undef, nil
+	}
+
+	return CIDFromBytes(data)
+}

--- a/internal/envelope/cid.go
+++ b/internal/envelope/cid.go
@@ -6,7 +6,6 @@ import (
 	"io"
 
 	"github.com/ipfs/go-cid"
-	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/multiformats/go-multibase"
 	"github.com/multiformats/go-multicodec"
 	"github.com/multiformats/go-multihash"
@@ -18,17 +17,6 @@ var b58BTCEnc = multibase.MustNewEncoder(multibase.Base58BTC)
 // string representation used by UCAN.
 func CIDToBase58BTC(id cid.Cid) string {
 	return id.Encode(b58BTCEnc)
-}
-
-// CID returns the UCAN content identifier a Tokener.
-// TODO: remove?
-func CID(privKey crypto.PrivKey, token Tokener) (cid.Cid, error) {
-	data, err := ToDagCbor(privKey, token)
-	if err != nil {
-		return cid.Undef, err
-	}
-
-	return CIDFromBytes(data)
 }
 
 // CIDFromBytes returns the UCAN content identifier for an arbitrary slice

--- a/internal/envelope/cid.go
+++ b/internal/envelope/cid.go
@@ -43,8 +43,8 @@ func CIDFromBytes(b []byte) (cid.Cid, error) {
 
 var _ io.Reader = (*CIDReader)(nil)
 
-// CIDReader wraps an io.Reader and includes a hash.Hash that is updated
-// as data is read from the child io.Reader.
+// CIDReader wraps an io.Reader and includes a hash.Hash that is
+// incrementally updated as data is read from the child io.Reader.
 type CIDReader struct {
 	hash hash.Hash
 	r    io.Reader
@@ -52,7 +52,7 @@ type CIDReader struct {
 }
 
 // NewCIDReader initializes a hash.Hash to calculate the CID's hash and
-// and returns a wrapped io.Reader.
+// returns the wrapped io.Reader.
 func NewCIDReader(r io.Reader) *CIDReader {
 	h := sha256.New()
 	h.Reset()
@@ -64,7 +64,7 @@ func NewCIDReader(r io.Reader) *CIDReader {
 }
 
 // CID returns the UCAN-formatted cid.Cid created from the hash calculated
-// as bytes are read from the inner io.Reader.
+// as bytes were read from the inner io.Reader.
 func (r *CIDReader) CID() (cid.Cid, error) {
 	if r.err != nil {
 		return cid.Undef, r.err // TODO: Wrap to say it's an error during streaming?
@@ -89,12 +89,16 @@ func (r *CIDReader) Read(p []byte) (n int, err error) {
 
 var _ io.Writer = (*CIDWriter)(nil)
 
+// CIDWriter wraps an io.Writer and includes a hash.Hash that is
+// incrementally updated as data is written to the child io.Writer.
 type CIDWriter struct {
 	hash hash.Hash
 	w    io.Writer
 	err  error
 }
 
+// NewCIDWriter initializes a hash.Hash to calculate the CID's hash and
+// returns the wrapped io.Writer.
 func NewCIDWriter(w io.Writer) *CIDWriter {
 	h := sha256.New()
 	h.Reset()
@@ -105,10 +109,13 @@ func NewCIDWriter(w io.Writer) *CIDWriter {
 	}
 }
 
+// CID returns the UCAN-formatted cid.Cid created from the hash calculated
+// as bytes were written from the inner io.Reader.
 func (w *CIDWriter) CID() (cid.Cid, error) {
 	return cidFromHash(w.hash)
 }
 
+// Write implements io.Writer.
 func (w *CIDWriter) Write(p []byte) (n int, err error) {
 	if _, err = w.hash.Write(p); err != nil {
 		w.err = err

--- a/internal/envelope/cid_test.go
+++ b/internal/envelope/cid_test.go
@@ -1,8 +1,10 @@
 package envelope_test
 
 import (
+	"io"
 	"testing"
 
+	"github.com/ipfs/go-cid"
 	"github.com/multiformats/go-multicodec"
 	"github.com/multiformats/go-multihash"
 	"github.com/stretchr/testify/assert"
@@ -22,4 +24,59 @@ func TestCid(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, exampleCID, envelope.CIDToBase58BTC(id))
 	assert.Equal(t, expHash, id.Hash())
+}
+
+func TestStreaming(t *testing.T) {
+	t.Parallel()
+
+	expData := []byte("this is a test")
+
+	expCID, err := cid.V1Builder{
+		Codec:    uint64(multicodec.DagCbor),
+		MhType:   multihash.SHA2_256,
+		MhLength: 0,
+	}.Sum(expData)
+	require.NoError(t, err)
+
+	t.Run("CIDReader()", func(t *testing.T) {
+		t.Parallel()
+
+		r, w := io.Pipe() //nolint:varnamelen
+		cidReader := envelope.NewCIDReader(r)
+
+		go func() {
+			_, err := w.Write(expData)
+			assert.NoError(t, err)
+			assert.NoError(t, w.Close())
+		}()
+
+		actData, err := io.ReadAll(cidReader)
+		require.NoError(t, err)
+		assert.Equal(t, expData, actData)
+
+		actCID, err := cidReader.CID()
+		require.NoError(t, err)
+		assert.Equal(t, expCID, actCID)
+	})
+
+	t.Run("CIDWriter", func(t *testing.T) {
+		t.Parallel()
+
+		r, w := io.Pipe() //nolint:varnamelen
+		cidWriter := envelope.NewCIDWriter(w)
+
+		go func() {
+			_, err := cidWriter.Write(expData)
+			assert.NoError(t, err)
+			assert.NoError(t, w.Close())
+		}()
+
+		actData, err := io.ReadAll(r)
+		require.NoError(t, err)
+		assert.Equal(t, expData, actData)
+
+		actCID, err := cidWriter.CID()
+		require.NoError(t, err)
+		assert.Equal(t, expCID, actCID)
+	})
 }

--- a/internal/envelope/cid_test.go
+++ b/internal/envelope/cid_test.go
@@ -1,0 +1,25 @@
+package envelope_test
+
+import (
+	"testing"
+
+	"github.com/multiformats/go-multicodec"
+	"github.com/multiformats/go-multihash"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/ucan-wg/go-ucan/internal/envelope"
+	"gotest.tools/v3/golden"
+)
+
+func TestCid(t *testing.T) {
+	t.Parallel()
+
+	expData := golden.Get(t, "example.dagcbor")
+	expHash, err := multihash.Sum(expData, uint64(multicodec.Sha2_256), -1)
+	require.NoError(t, err)
+
+	id, err := envelope.CID(examplePrivKey(t), newExample(t))
+	require.NoError(t, err)
+	assert.Equal(t, exampleCID, envelope.CIDToBase58BTC(id))
+	assert.Equal(t, expHash, id.Hash())
+}

--- a/internal/envelope/cid_test.go
+++ b/internal/envelope/cid_test.go
@@ -14,14 +14,17 @@ import (
 	"github.com/ucan-wg/go-ucan/internal/envelope"
 )
 
-func TestCid(t *testing.T) {
+func TestCidFromBytes(t *testing.T) {
 	t.Parallel()
 
 	expData := golden.Get(t, "example.dagcbor")
 	expHash, err := multihash.Sum(expData, uint64(multicodec.Sha2_256), -1)
 	require.NoError(t, err)
 
-	id, err := envelope.CID(examplePrivKey(t), newExample(t))
+	data, err := envelope.ToDagCbor(examplePrivKey(t), newExample(t))
+	require.NoError(t, err)
+
+	id, err := envelope.CIDFromBytes(data)
 	require.NoError(t, err)
 	assert.Equal(t, exampleCID, envelope.CIDToBase58BTC(id))
 	assert.Equal(t, expHash, id.Hash())

--- a/internal/envelope/example_test.go
+++ b/internal/envelope/example_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 const (
+	exampleCID             = "zdpuAyw6R5HvKSPzztuzXNYFx3ZGoMHMuAsXL6u3xLGQriRXQ"
 	exampleDID             = "did:key:z6MkpuK2Amsu1RqcLGgmHHQHhvmeXCCBVsM4XFSg2cCyg4Nh"
 	exampleGreeting        = "world"
 	examplePrivKeyCfg      = "CAESQP9v2uqECTuIi45dyg3znQvsryvf2IXmOF/6aws6aCehm0FVrj0zHR5RZSDxWNjcpcJqsGym3sjCungX9Zt5oA4="

--- a/internal/envelope/ipld_test.go
+++ b/internal/envelope/ipld_test.go
@@ -59,34 +59,68 @@ func TestEncode(t *testing.T) {
 func TestRoundtrip(t *testing.T) {
 	t.Parallel()
 
+	t.Run("via FromDagCbor/ToDagCbor", func(t *testing.T) {
+		t.Parallel()
+
+		dataIn := golden.Get(t, exampleDAGCBORFilename)
+
+		tkn, id, err := envelope.FromDagCbor[*Example](dataIn)
+		require.NoError(t, err)
+		assert.Equal(t, exampleGreeting, tkn.Hello)
+		assert.Equal(t, exampleDID, tkn.Issuer)
+		assert.Equal(t, exampleCID, envelope.CIDToBase58BTC(id))
+
+		dataOut, err := envelope.ToDagCbor(examplePrivKey(t), newExample(t))
+		require.NoError(t, err)
+		assert.Equal(t, dataIn, dataOut)
+	})
+
 	t.Run("via FromDagCborReader/ToDagCborWriter", func(t *testing.T) {
 		t.Parallel()
 
 		data := golden.Get(t, exampleDAGCBORFilename)
 
-		tkn, _, err := envelope.FromDagCborReader[*Example](bytes.NewReader(data))
+		tkn, id, err := envelope.FromDagCborReader[*Example](bytes.NewReader(data))
 		require.NoError(t, err)
 		assert.Equal(t, exampleGreeting, tkn.Hello)
 		assert.Equal(t, exampleDID, tkn.Issuer)
+		assert.Equal(t, exampleCID, envelope.CIDToBase58BTC(id))
 
 		w := &bytes.Buffer{}
 		require.NoError(t, envelope.ToDagCborWriter(w, examplePrivKey(t), newExample(t)))
 		assert.Equal(t, data, w.Bytes())
 	})
 
-	t.Run("via FromDagCbor/ToDagCbor", func(t *testing.T) {
+	t.Run("via FromDagJson/ToDagJson", func(t *testing.T) {
 		t.Parallel()
 
-		dataIn := golden.Get(t, exampleDAGCBORFilename)
+		dataIn := golden.Get(t, exampleDAGJSONFilename)
 
-		tkn, _, err := envelope.FromDagCbor[*Example](dataIn)
+		tkn, id, err := envelope.FromDagJson[*Example](dataIn)
 		require.NoError(t, err)
 		assert.Equal(t, exampleGreeting, tkn.Hello)
 		assert.Equal(t, exampleDID, tkn.Issuer)
+		assert.Equal(t, exampleCID, envelope.CIDToBase58BTC(id))
 
-		dataOut, err := envelope.ToDagCbor(examplePrivKey(t), newExample(t))
+		dataOut, err := envelope.ToDagJson(examplePrivKey(t), newExample(t))
 		require.NoError(t, err)
 		assert.Equal(t, dataIn, dataOut)
+	})
+
+	t.Run("via FromDagJsonReader/ToDagJsonrWriter", func(t *testing.T) {
+		t.Parallel()
+
+		data := golden.Get(t, exampleDAGJSONFilename)
+
+		tkn, id, err := envelope.FromDagJsonReader[*Example](bytes.NewReader(data))
+		require.NoError(t, err)
+		assert.Equal(t, exampleGreeting, tkn.Hello)
+		assert.Equal(t, exampleDID, tkn.Issuer)
+		assert.Equal(t, exampleCID, envelope.CIDToBase58BTC(id))
+
+		w := &bytes.Buffer{}
+		require.NoError(t, envelope.ToDagJsonWriter(w, examplePrivKey(t), newExample(t)))
+		assert.Equal(t, data, w.Bytes())
 	})
 }
 

--- a/internal/envelope/ipld_test.go
+++ b/internal/envelope/ipld_test.go
@@ -2,6 +2,7 @@ package envelope_test
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,7 +19,7 @@ func TestDecode(t *testing.T) {
 
 		data := golden.Get(t, "example.dagcbor")
 
-		tkn, _, err := envelope.FromDagCbor[*Example](data)
+		tkn, err := envelope.FromDagCbor[*Example](data)
 		require.NoError(t, err)
 		assert.Equal(t, exampleGreeting, tkn.Hello)
 		assert.Equal(t, exampleDID, tkn.Issuer)
@@ -29,7 +30,7 @@ func TestDecode(t *testing.T) {
 
 		data := golden.Get(t, "example.dagjson")
 
-		tkn, _, err := envelope.FromDagJson[*Example](data)
+		tkn, err := envelope.FromDagJson[*Example](data)
 		require.NoError(t, err)
 		assert.Equal(t, exampleGreeting, tkn.Hello)
 		assert.Equal(t, exampleDID, tkn.Issuer)
@@ -64,11 +65,10 @@ func TestRoundtrip(t *testing.T) {
 
 		dataIn := golden.Get(t, exampleDAGCBORFilename)
 
-		tkn, id, err := envelope.FromDagCbor[*Example](dataIn)
+		tkn, err := envelope.FromDagCbor[*Example](dataIn)
 		require.NoError(t, err)
 		assert.Equal(t, exampleGreeting, tkn.Hello)
 		assert.Equal(t, exampleDID, tkn.Issuer)
-		assert.Equal(t, exampleCID, envelope.CIDToBase58BTC(id))
 
 		dataOut, err := envelope.ToDagCbor(examplePrivKey(t), newExample(t))
 		require.NoError(t, err)
@@ -80,11 +80,10 @@ func TestRoundtrip(t *testing.T) {
 
 		data := golden.Get(t, exampleDAGCBORFilename)
 
-		tkn, id, err := envelope.FromDagCborReader[*Example](bytes.NewReader(data))
+		tkn, err := envelope.FromDagCborReader[*Example](bytes.NewReader(data))
 		require.NoError(t, err)
 		assert.Equal(t, exampleGreeting, tkn.Hello)
 		assert.Equal(t, exampleDID, tkn.Issuer)
-		assert.Equal(t, exampleCID, envelope.CIDToBase58BTC(id))
 
 		w := &bytes.Buffer{}
 		require.NoError(t, envelope.ToDagCborWriter(w, examplePrivKey(t), newExample(t)))
@@ -96,11 +95,10 @@ func TestRoundtrip(t *testing.T) {
 
 		dataIn := golden.Get(t, exampleDAGJSONFilename)
 
-		tkn, id, err := envelope.FromDagJson[*Example](dataIn)
+		tkn, err := envelope.FromDagJson[*Example](dataIn)
 		require.NoError(t, err)
 		assert.Equal(t, exampleGreeting, tkn.Hello)
 		assert.Equal(t, exampleDID, tkn.Issuer)
-		assert.Equal(t, exampleCID, envelope.CIDToBase58BTC(id))
 
 		dataOut, err := envelope.ToDagJson(examplePrivKey(t), newExample(t))
 		require.NoError(t, err)
@@ -112,11 +110,10 @@ func TestRoundtrip(t *testing.T) {
 
 		data := golden.Get(t, exampleDAGJSONFilename)
 
-		tkn, id, err := envelope.FromDagJsonReader[*Example](bytes.NewReader(data))
+		tkn, err := envelope.FromDagJsonReader[*Example](bytes.NewReader(data))
 		require.NoError(t, err)
 		assert.Equal(t, exampleGreeting, tkn.Hello)
 		assert.Equal(t, exampleDID, tkn.Issuer)
-		assert.Equal(t, exampleCID, envelope.CIDToBase58BTC(id))
 
 		w := &bytes.Buffer{}
 		require.NoError(t, envelope.ToDagJsonWriter(w, examplePrivKey(t), newExample(t)))
@@ -128,7 +125,27 @@ func TestFromIPLD_with_invalid_signature(t *testing.T) {
 	t.Parallel()
 
 	node := invalidNodeFromGolden(t)
-	tkn, _, err := envelope.FromIPLD[*Example](node)
+	tkn, err := envelope.FromIPLD[*Example](node)
 	assert.Nil(t, tkn)
 	require.EqualError(t, err, "failed to verify the token's signature")
+}
+
+func TestHash(t *testing.T) {
+	t.Parallel()
+
+	msg := []byte("this is a test")
+
+	hash1 := sha256.Sum256(msg)
+
+	hasher := sha256.New()
+
+	for _, b := range msg {
+		hasher.Write([]byte{b})
+	}
+
+	hash2 := hasher.Sum(nil)
+	hash3 := hasher.Sum(nil)
+
+	require.Equal(t, hash1[:], hash2)
+	require.Equal(t, hash1[:], hash3)
 }


### PR DESCRIPTION
This PR adds functions to calculate a UCAN CID for an `Envelope`.  CIDs are calculated during creation of a new `Delegation` via `New()` or `Root()` and for all decoding functions provided by the `envelope` package.  Please also review the exported API which as follows:

```
$ go doc -all ./delegation
package delegation // import "github.com/ucan-wg/go-ucan/delegation"

Package delegation implements the UCAN delegation specification with an
immutable Token type as well as methods to convert the Token to and from the
envelope-enclosed, signed and DAG-CBOR-encoded form that should most commonly be
used for transport and storage.

[delegation]: https://github.com/ucan-wg/delegation/tree/v1_ipld
[envelope]: https://github.com/ucan-wg/spec#envelope

CONSTANTS

const Tag = "ucan/dlg@1.0.0-rc.1"
    Tag is the string used as a key within the SigPayload that identifies that
    the TokenPayload is a delegation.

[Tag]: https://github.com/ucan-wg/delegation/tree/v1_ipld#type-tag


TYPES

type Option func(*Token) error
    Option is a type that allows optional fields to be set during the creation
    of a Token.

func WithExpiration(exp time.Time) Option
    WithExpiration set's the Token's optional "expiration" field to the value of
    the provided time.Time.

func WithMeta(key string, val any) Option
    WithMeta adds a key/value pair in the "meta" field.

    WithMeta can be used multiple times in the same call. Accepted types for the
    value are: bool, string, int, int32, int64, []byte, and ipld.Node.

func WithNonce(nonce []byte) Option
    WithNonce sets the Token's nonce with the given value. If this option is not
    used, a random 12-byte nonce is generated for this required field.

func WithNotBefore(nbf time.Time) Option
    WithNotBefore set's the Token's optional "notBefore" field to the value of
    the provided time.Time.

func WithSubject(sub did.DID) Option
    WithSubject sets the Tokens's optional "subject" field to the value of
    provided did.DID.

    This Option should only be used with the New constructor - since Subject
    is a required parameter when creating a Token via the Root constructor,
    any value provided via this Option will be silently overwritten.

type Token struct {
        // Has unexported fields.
}
    Token is an immutable type that holds the fields of a UCAN delegation.

func Decode(b []byte, decFn codec.Decoder) (*Token, error)
    Decode unmarshals the input data using the format specified by the provided
    codec.Decoder into a View.

    An error is returned if the conversion fails, or if the resulting View is
    invalid.

func DecodeReader(r io.Reader, decFn codec.Decoder) (*Token, error)
    DecodeReader is the same as Decode, but accept an io.Reader.

func FromDagCbor(data []byte) (*Token, error)
    FromDagCbor unmarshals the input data into a View.

    An error is returned if the conversion fails, or if the resulting View is
    invalid.

func FromDagCborReader(r io.Reader) (*Token, error)
    FromDagCborReader is the same as FromDagCbor, but accept an io.Reader.

func FromDagJson(data []byte) (*Token, error)
    FromDagJson unmarshals the input data into a View.

    An error is returned if the conversion fails, or if the resulting View is
    invalid.

func FromDagJsonReader(r io.Reader) (*Token, error)
    FromDagJsonReader is the same as FromDagJson, but accept an io.Reader.

func FromSealed(data []byte) (*Token, error)
    FromSealed decodes the provided binary data from the DAG-CBOR format,
    verifies that the envelope's signature is correct based on the public key
    taken from the issuer (iss) field and calculates the CID of the incoming
    data.

func FromSealedReader(r io.Reader) (*Token, error)
    FromSealedReader is the same as Unseal but accepts an io.Reader.

func New(privKey crypto.PrivKey, aud did.DID, cmd command.Command, pol policy.Policy, opts ...Option) (*Token, error)
    New creates a validated Token from the provided parameters and options.

func Root(privKey crypto.PrivKey, aud did.DID, cmd command.Command, pol policy.Policy, opts ...Option) (*Token, error)

func (t *Token) Audience() did.DID
    Audience returns the did.DID representing the Token's audience.

func (t *Token) CID() cid.Cid
    CID returns the content identifier of the Token model when enclosed in an
    Envelope and encoded to DAG-CBOR. Returns cid.Undef if the token has not
    been serialized or deserialized yet.

func (t *Token) Command() command.Command
    Command returns the capability's command.Command.

func (t *Token) Encode(privKey crypto.PrivKey, encFn codec.Encoder) ([]byte, error)
    Encode marshals a View to the format specified by the provided
    codec.Encoder.

func (t *Token) EncodeWriter(w io.Writer, privKey crypto.PrivKey, encFn codec.Encoder) error
    EncodeWriter is the same as Encode but accepts an io.Writer.

func (t *Token) Expiration() *time.Time
    Expiration returns the time at which the Token expires.

func (t *Token) Issuer() did.DID
    Issuer returns the did.DID representing the Token's issuer.

func (t *Token) Meta() *meta.Meta
    Meta returns the Token's metadata.

func (t *Token) Nonce() []byte
    Nonce returns the random Nonce encapsulated in this Token.

func (t *Token) NotBefore() *time.Time
    NotBefore returns the time at which the Token becomes "active".

func (t *Token) Policy() policy.Policy
    Policy returns the capability's policy.Policy.

func (t *Token) Subject() did.DID
    Subject returns the did.DID representing the Token's subject.

    This field may be did.Undef for delegations that are [Powerlined] but must
    be equal to the value returned by the Issuer method for root tokens.

func (t *Token) ToDagCbor(privKey crypto.PrivKey) ([]byte, error)
    ToDagCbor marshals the View to the DAG-CBOR format.

func (t *Token) ToDagCborWriter(w io.Writer, privKey crypto.PrivKey) error
    ToDagCborWriter is the same as ToDagCbor but it accepts an io.Writer.

func (t *Token) ToDagJson(privKey crypto.PrivKey) ([]byte, error)
    ToDagJson marshals the View to the DAG-JSON format.

func (t *Token) ToDagJsonWriter(w io.Writer, privKey crypto.PrivKey) error
    ToDagJsonWriter is the same as ToDagJson but it accepts an io.Writer.

func (t *Token) ToSealed(privKey crypto.PrivKey) ([]byte, cid.Cid, error)
    ToSealed wraps the delegation token in an envelope, generates the signature,
    encodes the result to DAG-CBOR and calculates the CID of the resulting
    binary data.

func (t *Token) ToSealedWriter(w io.Writer, privKey crypto.PrivKey) (cid.Cid, error)
    ToSealedWriter is the same as Seal but accepts an io.Writer.

```
