### PR TITLE
fix: change meta optional in `delegation` `Token`, model and schema

### DIFF
--- a/did/crypto.go
+++ b/did/crypto.go
@@ -204,8 +204,8 @@ func codeForCurve(pubKey crypto.PubKey) (multicodec.Code, error) {
 // package treats it as a different type and has a different format for
 // the raw bytes of the public key.
 //
-// If a valid ECDSA public key was created the secp256k1.S256 curve, this
-// function will "convert" it from a crypto.ECDSAPubKey to a
+// If a valid ECDSA public key was created using the secp256k1.S256 curve,
+// this function will "convert" it from a crypto.ECDSAPubKey to a
 // crypto.Secp256k1PublicKey.
 func coerceECDSAToSecp256k1(pubKey crypto.PubKey) (crypto.PubKey, error) {
 	stdPub, err := crypto.PubKeyToStdKey(pubKey)

--- a/token/delegation/delegation.go
+++ b/token/delegation/delegation.go
@@ -79,6 +79,10 @@ func New(privKey crypto.PrivKey, aud did.DID, cmd command.Command, pol policy.Po
 		}
 	}
 
+	if len(tkn.meta.Keys) < 1 {
+		tkn.meta = nil
+	}
+
 	if err := tkn.validate(); err != nil {
 		return nil, err
 	}
@@ -213,7 +217,7 @@ func tokenFromModel(m tokenPayloadModel) (*Token, error) {
 	}
 	tkn.nonce = m.Nonce
 
-	tkn.meta = &m.Meta
+	tkn.meta = m.Meta
 
 	if m.Nbf != nil {
 		t := time.Unix(*m.Nbf, 0)

--- a/token/delegation/delegation.ipldsch
+++ b/token/delegation/delegation.ipldsch
@@ -20,7 +20,7 @@ type Payload struct {
     nonce Bytes
 
     # Arbitrary Metadata
-    meta {String : Any}
+    meta optional {String : Any}
 
     # "Not before" UTC Unix Timestamp in seconds (valid from), 53-bits integer
     nbf optional Int

--- a/token/delegation/ipld.go
+++ b/token/delegation/ipld.go
@@ -224,7 +224,7 @@ func (t *Token) toIPLD(privKey crypto.PrivKey) (datamodel.Node, error) {
 		Cmd:   t.command.String(),
 		Pol:   pol,
 		Nonce: t.nonce,
-		Meta:  *t.meta,
+		Meta:  t.meta,
 		Nbf:   nbf,
 		Exp:   exp,
 	}

--- a/token/delegation/schema.go
+++ b/token/delegation/schema.go
@@ -66,7 +66,7 @@ type tokenPayloadModel struct {
 	Nonce []byte
 
 	// Arbitrary Metadata
-	Meta meta.Meta
+	Meta *meta.Meta
 
 	// "Not before" UTC Unix Timestamp in seconds (valid from), 53-bits integer
 	// optional: can be nil


### PR DESCRIPTION
While working on the serialization of `invocation` tokens, I noticed a problem with the `delegation` token.  The `meta` field should be optional in `delegation.ipldsch` and, if metadata is absent, the field shouldn't be included in serialization.  This isn't a problem for tokens we've generated so far (which would simply have be represented as `"meta": []` if serialized to DAG-JSON) as we'd decode that back into an empty but present `meta` field in the token.  This would however break our interoperability with other clients that wouldn't send the `meta` field at all if there was no metadata present.

This PR makes the `meta` field in the IPLD schema `optional` and makes it nillable in the associated Go types.