### PR TITLE
policy: add a global boolean to enable tracing on policy matching

### DIFF
--- a/pkg/policy/match.go
+++ b/pkg/policy/match.go
@@ -9,6 +9,9 @@ import (
 	"github.com/ipld/go-ipld-prime/must"
 )
 
+// MatchTrace, if set, will print tracing statements to stdout of the policy matching resolution.
+var MatchTrace = false
+
 // Match determines if the IPLD node satisfies the policy.
 func (p Policy) Match(node datamodel.Node) bool {
 	for _, stmt := range p {
@@ -59,13 +62,18 @@ const (
 // - matchResultNoData: if the selector didn't match the expected data.
 // For matchResultTrue and matchResultNoData, the leaf-most (innermost) statement failing to be true is returned,
 // as well as the corresponding root-most encompassing statement.
-func matchStatement(cur Statement, node ipld.Node) (_ matchResult, leafMost Statement) {
+func matchStatement(cur Statement, node ipld.Node) (output matchResult, leafMost Statement) {
 	var boolToRes = func(v bool) (matchResult, Statement) {
 		if v {
 			return matchResultTrue, nil
 		} else {
 			return matchResultFalse, cur
 		}
+	}
+	if MatchTrace {
+		defer func() {
+			fmt.Printf("match %v --> %v\n", cur, matchResToStr(output))
+		}()
 	}
 
 	switch cur.Kind() {
@@ -274,3 +282,18 @@ func gt(order int) bool  { return order == 1 }
 func gte(order int) bool { return order == 0 || order == 1 }
 func lt(order int) bool  { return order == -1 }
 func lte(order int) bool { return order == 0 || order == -1 }
+
+func matchResToStr(res matchResult) string {
+	switch res {
+	case matchResultTrue:
+		return "True"
+	case matchResultFalse:
+		return "False"
+	case matchResultNoData:
+		return "NoData"
+	case matchResultOptionalNoData:
+		return "OptionalNoData"
+	default:
+		panic("invalid matchResult")
+	}
+}


### PR DESCRIPTION
I find that quite convenient, but not sure it has a place in the final code.

```
=== RUN   TestJsonRpc
=== RUN   TestJsonRpc/or_on_method,_not_matching
match ["==", ".jsonrpc.method", "eth_getCode"] --> False
match ["==", ".jsonrpc.method", "eth_getBalance"] --> False
match ["==", ".jsonrpc.method", "eth_call"] --> False
match ["==", ".jsonrpc.method", "eth_blockNumber"] --> False
match ["or", [
  ["==", ".jsonrpc.method", "eth_getCode"],
  ["==", ".jsonrpc.method", "eth_getBalance"],
  ["==", ".jsonrpc.method", "eth_call"],
  ["==", ".jsonrpc.method", "eth_blockNumber"]]]
 --> False
--- PASS: TestJsonRpc/or_on_method,_not_matching (0.00s)
=== RUN   TestJsonRpc/or_on_method,_matching
match ["==", ".jsonrpc.method", "eth_getCode"] --> False
match ["==", ".jsonrpc.method", "eth_getBalance"] --> False
match ["==", ".jsonrpc.method", "eth_call"] --> True
match ["or", [
  ["==", ".jsonrpc.method", "eth_getCode"],
  ["==", ".jsonrpc.method", "eth_getBalance"],
  ["==", ".jsonrpc.method", "eth_call"],
  ["==", ".jsonrpc.method", "eth_blockNumber"]]]
 --> True
--- PASS: TestJsonRpc/or_on_method,_matching (0.00s)
=== RUN   TestJsonRpc/complex,_optional_parameter,_matching
match ["==", ".jsonrpc.method", "debug_traceCall"] --> True
match ["==", ".jsonrpc.params[3]?", "callTracer"] --> True
match ["or", [
  ["==", ".jsonrpc.params[3]?", "callTracer"],
  ["==", ".jsonrpc.params[3]?", "prestateTracer"]]]
 --> True
--- PASS: TestJsonRpc/complex,_optional_parameter,_matching (0.00s)
=== RUN   TestJsonRpc/complex,_optional_parameter,_missing_parameter
match ["==", ".jsonrpc.method", "debug_traceCall"] --> True
match ["==", ".jsonrpc.params[3]?", "callTracer"] --> OptionalNoData
match ["or", [
  ["==", ".jsonrpc.params[3]?", "callTracer"],
  ["==", ".jsonrpc.params[3]?", "prestateTracer"]]]
 --> OptionalNoData
--- PASS: TestJsonRpc/complex,_optional_parameter,_missing_parameter (0.00s)
=== RUN   TestJsonRpc/complex,_parameter_not_matching
match ["==", ".jsonrpc.method", "debug_traceCall"] --> True
match ["==", ".jsonrpc.params[3]?", "callTracer"] --> False
match ["==", ".jsonrpc.params[3]?", "prestateTracer"] --> False
match ["or", [
  ["==", ".jsonrpc.params[3]?", "callTracer"],
  ["==", ".jsonrpc.params[3]?", "prestateTracer"]]]
 --> False
--- PASS: TestJsonRpc/complex,_parameter_not_matching (0.00s)
--- PASS: TestJsonRpc (0.00s)
PASS``` 