### PR TITLE
args: simplify API + code

### DIFF
--- a/pkg/args/args.go
+++ b/pkg/args/args.go
@@ -5,41 +5,17 @@ package args
 
 import (
 	"fmt"
-	"reflect"
-	"sync"
+	"sort"
 
-	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
-	"github.com/ipld/go-ipld-prime/node/bindnode"
-	"github.com/ipld/go-ipld-prime/schema"
+	"github.com/ipld/go-ipld-prime/datamodel"
+	"github.com/ipld/go-ipld-prime/fluent/qp"
+	"github.com/ipld/go-ipld-prime/node/basicnode"
+
 	"github.com/ucan-wg/go-ucan/pkg/policy/literal"
 )
 
-const (
-	argsSchema = "type Args { String : Any }"
-	argsName   = "Args"
-)
-
-var (
-	once sync.Once
-	ts   *schema.TypeSystem
-	err  error
-)
-
-func argsType() schema.Type {
-	once.Do(func() {
-		ts, err = ipld.LoadSchemaBytes([]byte(argsSchema))
-	})
-	if err != nil {
-		panic(err)
-	}
-
-	return ts.TypeByName(argsName)
-}
-
-var ErrUnsupported = fmt.Errorf("failure adding unsupported type to meta")
-
-// Args are the Command's argumennts when an invocation Token is processed
+// Args are the Command's arguments when an invocation Token is processed
 // by the executor.
 //
 // This type must be compatible with the IPLD type represented by the IPLD
@@ -56,41 +32,23 @@ func New() *Args {
 	}
 }
 
-// FromIPLD unwraps an Args instance from an ipld.Node.
-func FromIPLD(node ipld.Node) (*Args, error) {
-	var err error
-
-	defer func() {
-		err = handlePanic(recover())
-	}()
-
-	obj := bindnode.Unwrap(node)
-
-	args, ok := obj.(*Args)
-	if !ok {
-		err = fmt.Errorf("failed to convert to Args")
-	}
-
-	return args, err
-}
-
 // Add inserts a key/value pair in the Args set.
 //
 // Accepted types for val are: bool, string, int, int8, int16,
 // int32, int64, uint, uint8, uint16, uint32, float32, float64, []byte,
 // []any, map[string]any, ipld.Node and nil.
-func (m *Args) Add(key string, val any) error {
-	if _, ok := m.Values[key]; ok {
+func (a *Args) Add(key string, val any) error {
+	if _, ok := a.Values[key]; ok {
 		return fmt.Errorf("duplicate key %q", key)
 	}
 
-	node, err := anyNode(val)
+	node, err := literal.Any(val)
 	if err != nil {
 		return err
 	}
 
-	m.Values[key] = node
-	m.Keys = append(m.Keys, key)
+	a.Values[key] = node
+	a.Keys = append(a.Keys, key)
 
 	return nil
 }
@@ -99,108 +57,39 @@ func (m *Args) Add(key string, val any) error {
 //
 // If duplicate keys are encountered, the new value is silently dropped
 // without causing an error.
-func (m *Args) Include(other *Args) {
+func (a *Args) Include(other *Args) {
 	for _, key := range other.Keys {
-		if _, ok := m.Values[key]; ok {
+		if _, ok := a.Values[key]; ok {
 			// don't overwrite
 			continue
 		}
-		m.Values[key] = other.Values[key]
-		m.Keys = append(m.Keys, key)
+		a.Values[key] = other.Values[key]
+		a.Keys = append(a.Keys, key)
 	}
 }
 
 // ToIPLD wraps an instance of an Args with an ipld.Node.
-func (m *Args) ToIPLD() (ipld.Node, error) {
-	var err error
-
-	defer func() {
-		err = handlePanic(recover())
-	}()
-
-	return bindnode.Wrap(m, argsType()), err
+func (a *Args) ToIPLD() (ipld.Node, error) {
+	sort.Strings(a.Keys)
+	return qp.BuildMap(basicnode.Prototype.Any, int64(len(a.Keys)), func(ma datamodel.MapAssembler) {
+		for _, key := range a.Keys {
+			qp.MapEntry(ma, key, qp.Node(a.Values[key]))
+		}
+	})
 }
 
-func anyNode(val any) (ipld.Node, error) {
-	var err error
-
-	defer func() {
-		err = handlePanic(recover())
-	}()
-
-	if val == nil {
-		return literal.Null(), nil
+// Equals tells if two Args hold the same values.
+func (a *Args) Equals(other *Args) bool {
+	if len(a.Keys) != len(other.Keys) {
+		return false
 	}
-
-	if cast, ok := val.(ipld.Node); ok {
-		return cast, nil
+	if len(a.Values) != len(other.Values) {
+		return false
 	}
-
-	if cast, ok := val.(cid.Cid); ok {
-		return literal.LinkCid(cast), err
-	}
-
-	var rv reflect.Value
-
-	rv.Kind()
-
-	if cast, ok := val.(reflect.Value); ok {
-		rv = cast
-	} else {
-		rv = reflect.ValueOf(val)
-	}
-
-	for rv.Kind() == reflect.Ptr || rv.Kind() == reflect.Interface {
-		rv = rv.Elem()
-	}
-
-	switch rv.Kind() {
-	case reflect.Slice:
-		if rv.Type().Elem().Kind() == reflect.Uint8 {
-			return literal.Bytes(val.([]byte)), nil
+	for _, key := range a.Keys {
+		if !ipld.DeepEqual(a.Values[key], other.Values[key]) {
+			return false
 		}
-
-		l := make([]reflect.Value, rv.Len())
-
-		for i := 0; i < rv.Len(); i++ {
-			l[i] = rv.Index(i)
-		}
-
-		return literal.List(l)
-	case reflect.Map:
-		if rv.Type().Key().Kind() != reflect.String {
-			return nil, fmt.Errorf("unsupported map key type: %s", rv.Type().Key().Name())
-		}
-
-		m := make(map[string]reflect.Value, rv.Len())
-		it := rv.MapRange()
-
-		for it.Next() {
-			m[it.Key().String()] = it.Value()
-		}
-
-		return literal.Map(m)
-	case reflect.String:
-		return literal.String(rv.String()), nil
-	case reflect.Bool:
-		return literal.Bool(rv.Bool()), nil
-		// reflect.Int64 may exceed the safe 53-bit limit of JavaScript
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return literal.Int(rv.Int()), nil
-	// reflect.Uint64 can't be safely converted to int64
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32:
-		return literal.Int(int64(rv.Uint())), nil
-	case reflect.Float32, reflect.Float64:
-		return literal.Float(rv.Float()), nil
-	default:
-		return nil, fmt.Errorf("unsupported Args type: %s", rv.Type().Name())
 	}
-}
-
-func handlePanic(rec any) error {
-	if err, ok := rec.(error); ok {
-		return err
-	}
-
-	return fmt.Errorf("%v", rec)
+	return true
 }

--- a/pkg/args/args.go
+++ b/pkg/args/args.go
@@ -15,12 +15,13 @@ import (
 	"github.com/ucan-wg/go-ucan/pkg/policy/literal"
 )
 
-// Args are the Command's arguments when an invocation Token is processed
-// by the executor.
-//
-// This type must be compatible with the IPLD type represented by the IPLD
-// schema { String : Any }.
+// Args are the Command's arguments when an invocation Token is processed by the executor.
+// This also serves as a way to construct the underlying IPLD data with minimum allocations
+// and transformations, while hiding the IPLD complexity from the caller.
 type Args struct {
+	// This type must be compatible with the IPLD type represented by the IPLD
+	// schema { String : Any }.
+
 	Keys   []string
 	Values map[string]ipld.Node
 }
@@ -34,9 +35,7 @@ func New() *Args {
 
 // Add inserts a key/value pair in the Args set.
 //
-// Accepted types for val are: bool, string, int, int8, int16,
-// int32, int64, uint, uint8, uint16, uint32, float32, float64, []byte,
-// []any, map[string]any, ipld.Node and nil.
+// Accepted types for val are any CBOR compatible type, or directly IPLD values.
 func (a *Args) Add(key string, val any) error {
 	if _, ok := a.Values[key]; ok {
 		return fmt.Errorf("duplicate key %q", key)

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -2,23 +2,23 @@ package meta
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 
 	"github.com/ipld/go-ipld-prime"
-	"github.com/ipld/go-ipld-prime/datamodel"
-	"github.com/ipld/go-ipld-prime/node/basicnode"
 	"github.com/ipld/go-ipld-prime/printer"
-)
 
-var ErrUnsupported = fmt.Errorf("failure adding unsupported type to meta")
+	"github.com/ucan-wg/go-ucan/pkg/policy/literal"
+)
 
 var ErrNotFound = fmt.Errorf("key-value not found in meta")
 
 // Meta is a container for meta key-value pairs in a UCAN token.
-// This also serves as a way to construct the underlying IPLD data with minimum allocations and transformations,
-// while hiding the IPLD complexity from the caller.
+// This also serves as a way to construct the underlying IPLD data with minimum allocations
+// and transformations, while hiding the IPLD complexity from the caller.
 type Meta struct {
+	// This type must be compatible with the IPLD type represented by the IPLD
+	// schema { String : Any }.
+
 	Keys   []string
 	Values map[string]ipld.Node
 }
@@ -95,35 +95,20 @@ func (m *Meta) GetNode(key string) (ipld.Node, error) {
 }
 
 // Add adds a key/value pair in the meta set.
-// Accepted types for the value are: bool, string, int, int32, int64, []byte,
-// and ipld.Node.
+// Accepted types for val are any CBOR compatible type, or directly IPLD values.
 func (m *Meta) Add(key string, val any) error {
 	if _, ok := m.Values[key]; ok {
 		return fmt.Errorf("duplicate key %q", key)
 	}
-	switch val := val.(type) {
-	case bool:
-		m.Values[key] = basicnode.NewBool(val)
-	case string:
-		m.Values[key] = basicnode.NewString(val)
-	case int:
-		m.Values[key] = basicnode.NewInt(int64(val))
-	case int32:
-		m.Values[key] = basicnode.NewInt(int64(val))
-	case int64:
-		m.Values[key] = basicnode.NewInt(val)
-	case float32:
-		m.Values[key] = basicnode.NewFloat(float64(val))
-	case float64:
-		m.Values[key] = basicnode.NewFloat(val)
-	case []byte:
-		m.Values[key] = basicnode.NewBytes(val)
-	case datamodel.Node:
-		m.Values[key] = val
-	default:
-		return fmt.Errorf("%w: %s", ErrUnsupported, fqtn(val))
+
+	node, err := literal.Any(val)
+	if err != nil {
+		return err
 	}
+
 	m.Keys = append(m.Keys, key)
+	m.Values[key] = node
+
 	return nil
 }
 
@@ -165,16 +150,4 @@ func (m *Meta) String() string {
 // ReadOnly returns a read-only version of Meta.
 func (m *Meta) ReadOnly() ReadOnly {
 	return ReadOnly{m: m}
-}
-
-func fqtn(val any) string {
-	var name string
-
-	t := reflect.TypeOf(val)
-	for t.Kind() == reflect.Pointer {
-		name += "*"
-		t = t.Elem()
-	}
-
-	return name + t.PkgPath() + "." + t.Name()
 }

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"gotest.tools/v3/assert"
 
 	"github.com/ucan-wg/go-ucan/pkg/meta"
 )
@@ -18,7 +17,6 @@ func TestMeta_Add(t *testing.T) {
 		t.Parallel()
 
 		err := (&meta.Meta{}).Add("invalid", &Unsupported{})
-		require.ErrorIs(t, err, meta.ErrUnsupported)
-		assert.ErrorContains(t, err, "*github.com/ucan-wg/go-ucan/pkg/meta_test.Unsupported")
+		require.Error(t, err)
 	})
 }

--- a/pkg/policy/literal/literal.go
+++ b/pkg/policy/literal/literal.go
@@ -58,6 +58,47 @@ func List[T any](l []T) (ipld.Node, error) {
 // Any creates an IPLD node from any value
 // If possible, use another dedicated function for your type for performance.
 func Any(v any) (res ipld.Node, err error) {
+	// TODO: handle uint overflow below
+
+	// some fast path
+	switch val := v.(type) {
+	case bool:
+		return basicnode.NewBool(val), nil
+	case string:
+		return basicnode.NewString(val), nil
+	case int:
+		return basicnode.NewInt(int64(val)), nil
+	case int8:
+		return basicnode.NewInt(int64(val)), nil
+	case int16:
+		return basicnode.NewInt(int64(val)), nil
+	case int32:
+		return basicnode.NewInt(int64(val)), nil
+	case int64:
+		return basicnode.NewInt(val), nil
+	case uint:
+		return basicnode.NewInt(int64(val)), nil
+	case uint8:
+		return basicnode.NewInt(int64(val)), nil
+	case uint16:
+		return basicnode.NewInt(int64(val)), nil
+	case uint32:
+		return basicnode.NewInt(int64(val)), nil
+	case uint64:
+		return basicnode.NewInt(int64(val)), nil
+	case float32:
+		return basicnode.NewFloat(float64(val)), nil
+	case float64:
+		return basicnode.NewFloat(val), nil
+	case []byte:
+		return basicnode.NewBytes(val), nil
+	case datamodel.Node:
+		return val, nil
+	case cid.Cid:
+		return LinkCid(val), nil
+	default:
+	}
+
 	builder := basicnode.Prototype__Any{}.NewBuilder()
 
 	defer func() {

--- a/pkg/policy/literal/literal_test.go
+++ b/pkg/policy/literal/literal_test.go
@@ -218,6 +218,42 @@ func TestAny(t *testing.T) {
 	require.Error(t, err)
 }
 
+func BenchmarkAny(b *testing.B) {
+	b.Run("bool", func(b *testing.B) {
+		b.ReportAllocs()
+
+		for n := 0; n < b.N; n++ {
+			_, _ = Any(true)
+		}
+	})
+
+	b.Run("string", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			_, _ = Any("foobar")
+		}
+	})
+
+	b.Run("bytes", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			_, _ = Any([]byte{1, 2, 3, 4})
+		}
+	})
+
+	b.Run("map", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			_, _ = Any(map[string]any{
+				"foo": "bar",
+				"foofoo": map[string]string{
+					"barbar": "foo",
+				},
+			})
+		}
+	})
+}
+
 func must[T any](t T, err error) T {
 	if err != nil {
 		panic(err)

--- a/pkg/policy/literal/literal_test.go
+++ b/pkg/policy/literal/literal_test.go
@@ -3,7 +3,9 @@ package literal
 import (
 	"testing"
 
+	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime/datamodel"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/ipld/go-ipld-prime/printer"
 	"github.com/stretchr/testify/require"
 )
@@ -53,6 +55,7 @@ func TestMap(t *testing.T) {
 				"barbar": "foo",
 			},
 		},
+		"link": cid.MustParse("bafzbeigai3eoy2ccc7ybwjfz5r3rdxqrinwi4rwytly24tdbh6yk7zslrm"),
 	})
 	require.NoError(t, err)
 
@@ -115,6 +118,104 @@ func TestMap(t *testing.T) {
 		string{"barbar"}: string{"foo"}
 	}
 }`, printer.Sprint(v))
+
+	v, err = n.LookupByString("link")
+	require.NoError(t, err)
+	require.Equal(t, datamodel.Kind_Link, v.Kind())
+	asLink, err := v.AsLink()
+	require.NoError(t, err)
+	require.True(t, asLink.(cidlink.Link).Equals(cid.MustParse("bafzbeigai3eoy2ccc7ybwjfz5r3rdxqrinwi4rwytly24tdbh6yk7zslrm")))
+}
+
+func TestAny(t *testing.T) {
+	data := map[string]any{
+		"bool":   true,
+		"string": "foobar",
+		"bytes":  []byte{1, 2, 3, 4},
+		"int":    1234,
+		"uint":   uint(12345),
+		"float":  1.45,
+		"slice":  []int{1, 2, 3},
+		"array":  [2]int{1, 2},
+		"map": map[string]any{
+			"foo": "bar",
+			"foofoo": map[string]string{
+				"barbar": "foo",
+			},
+		},
+		"link": cid.MustParse("bafzbeigai3eoy2ccc7ybwjfz5r3rdxqrinwi4rwytly24tdbh6yk7zslrm"),
+		"func": func() {},
+	}
+
+	v, err := Any(data["bool"])
+	require.NoError(t, err)
+	require.Equal(t, datamodel.Kind_Bool, v.Kind())
+	require.Equal(t, true, must(v.AsBool()))
+
+	v, err = Any(data["string"])
+	require.NoError(t, err)
+	require.Equal(t, datamodel.Kind_String, v.Kind())
+	require.Equal(t, "foobar", must(v.AsString()))
+
+	v, err = Any(data["bytes"])
+	require.NoError(t, err)
+	require.Equal(t, datamodel.Kind_Bytes, v.Kind())
+	require.Equal(t, []byte{1, 2, 3, 4}, must(v.AsBytes()))
+
+	v, err = Any(data["int"])
+	require.NoError(t, err)
+	require.Equal(t, datamodel.Kind_Int, v.Kind())
+	require.Equal(t, int64(1234), must(v.AsInt()))
+
+	v, err = Any(data["uint"])
+	require.NoError(t, err)
+	require.Equal(t, datamodel.Kind_Int, v.Kind())
+	require.Equal(t, int64(12345), must(v.AsInt()))
+
+	v, err = Any(data["float"])
+	require.NoError(t, err)
+	require.Equal(t, datamodel.Kind_Float, v.Kind())
+	require.Equal(t, 1.45, must(v.AsFloat()))
+
+	v, err = Any(data["slice"])
+	require.NoError(t, err)
+	require.Equal(t, datamodel.Kind_List, v.Kind())
+	require.Equal(t, int64(3), v.Length())
+	require.Equal(t, `list{
+	0: int{1}
+	1: int{2}
+	2: int{3}
+}`, printer.Sprint(v))
+
+	v, err = Any(data["array"])
+	require.NoError(t, err)
+	require.Equal(t, datamodel.Kind_List, v.Kind())
+	require.Equal(t, int64(2), v.Length())
+	require.Equal(t, `list{
+	0: int{1}
+	1: int{2}
+}`, printer.Sprint(v))
+
+	v, err = Any(data["map"])
+	require.NoError(t, err)
+	require.Equal(t, datamodel.Kind_Map, v.Kind())
+	require.Equal(t, int64(2), v.Length())
+	require.Equal(t, `map{
+	string{"foo"}: string{"bar"}
+	string{"foofoo"}: map{
+		string{"barbar"}: string{"foo"}
+	}
+}`, printer.Sprint(v))
+
+	v, err = Any(data["link"])
+	require.NoError(t, err)
+	require.Equal(t, datamodel.Kind_Link, v.Kind())
+	asLink, err := v.AsLink()
+	require.NoError(t, err)
+	require.True(t, asLink.(cidlink.Link).Equals(cid.MustParse("bafzbeigai3eoy2ccc7ybwjfz5r3rdxqrinwi4rwytly24tdbh6yk7zslrm")))
+
+	v, err = Any(data["func"])
+	require.Error(t, err)
 }
 
 func must[T any](t T, err error) T {

--- a/token/internal/envelope/ipld.go
+++ b/token/internal/envelope/ipld.go
@@ -187,6 +187,8 @@ func FromIPLD[T Tokener](node datamodel.Node) (T, error) {
 		return zero, errors.New("the VarsigHeader key type doesn't match the issuer's key type")
 	}
 
+	// TODO: this re-encode the payload! Is there a less wasteful way?
+
 	data, err := ipld.Encode(info.sigPayloadNode, dagcbor.Encode)
 	if err != nil {
 		return zero, err


### PR DESCRIPTION
TL:DR:
- add `Any` in `literal`
- make `literal` handle Links
- make `Args` use that code
- remove `FromIPLD` in args as we don't need it beside for testing, adapt the testing code
- add fast paths in `literal.Any` for common types