### PR TITLE
feat(container): versioning

### DIFF
--- a/pkg/container/car_test.go
+++ b/pkg/container/car_test.go
@@ -40,6 +40,13 @@ func TestCarRoundTrip(t *testing.T) {
 }
 
 func FuzzCarRoundTrip(f *testing.F) {
+	// Note: this fuzzing is somewhat broken.
+	// After some time, the fuzzer discover that a varint can be serialized in different
+	// ways that lead to the same integer value. This means that the CAR format can have
+	// multiple legal binary representation for the exact same data, which is what we are
+	// trying to detect here. Ideally, the format would be stricter, but that's how things
+	// are.
+
 	example, err := os.ReadFile("testdata/sample-v1.car")
 	require.NoError(f, err)
 

--- a/pkg/container/writer.go
+++ b/pkg/container/writer.go
@@ -14,6 +14,8 @@ import (
 
 // TODO: should we have a multibase to wrap the cbor? but there is no reader/write in go-multibase :-(
 
+const currentContainerVersion = "ctn-v1"
+
 // Writer is a token container writer. It provides a convenient way to aggregate and serialize tokens together.
 type Writer map[cid.Cid][]byte
 
@@ -43,10 +45,12 @@ func (ctn Writer) ToCarBase64(w io.Writer) error {
 }
 
 func (ctn Writer) ToCbor(w io.Writer) error {
-	node, err := qp.BuildList(basicnode.Prototype.Any, int64(len(ctn)), func(la datamodel.ListAssembler) {
-		for _, bytes := range ctn {
-			qp.ListEntry(la, qp.Bytes(bytes))
-		}
+	node, err := qp.BuildMap(basicnode.Prototype.Any, 1, func(ma datamodel.MapAssembler) {
+		qp.MapEntry(ma, currentContainerVersion, qp.List(int64(len(ctn)), func(la datamodel.ListAssembler) {
+			for _, bytes := range ctn {
+				qp.ListEntry(la, qp.Bytes(bytes))
+			}
+		}))
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Right now, the model is the IPLD equivalent of:
```
[]any{
   tkn1,
   tkn2,
},
```

Let's change it to something like:
```
map[string]any{
   "ctn-v1": []any{
      tkn1,
      tkn2,
   },
}
```