### PR TITLE
fix(selector): allow dashes in selector names

### DIFF
--- a/pkg/policy/selector/parsing.go
+++ b/pkg/policy/selector/parsing.go
@@ -11,7 +11,7 @@ import (
 var (
 	indexRegex = regexp.MustCompile(`^-?\d+$`)
 	sliceRegex = regexp.MustCompile(`^((\-?\d+:\-?\d*)|(\-?\d*:\-?\d+))$`)
-	fieldRegex = regexp.MustCompile(`^\.[a-zA-Z_]*?$`)
+	fieldRegex = regexp.MustCompile(`^\.[a-zA-Z_-]*?$`)
 )
 
 func Parse(str string) (Selector, error) {

--- a/pkg/policy/selector/parsing_test.go
+++ b/pkg/policy/selector/parsing_test.go
@@ -30,6 +30,29 @@ func TestParse(t *testing.T) {
 		require.Empty(t, sel[0].Slice())
 		require.Equal(t, sel[0].Field(), "foo")
 		require.Empty(t, sel[0].Index())
+
+		sel, err = Parse(".foo_bar")
+		require.NoError(t, err)
+		require.Equal(t, 1, len(sel))
+		require.False(t, sel[0].Identity())
+		require.False(t, sel[0].Optional())
+		require.False(t, sel[0].Iterator())
+		require.Empty(t, sel[0].Slice())
+		require.Equal(t, sel[0].Field(), "foo_bar")
+		require.Empty(t, sel[0].Index())
+
+		sel, err = Parse(".foo-bar")
+		require.NoError(t, err)
+		require.Equal(t, 1, len(sel))
+		require.False(t, sel[0].Identity())
+		require.False(t, sel[0].Optional())
+		require.False(t, sel[0].Iterator())
+		require.Empty(t, sel[0].Slice())
+		require.Equal(t, sel[0].Field(), "foo-bar")
+		require.Empty(t, sel[0].Index())
+
+		sel, err = Parse(".foo*bar")
+		require.ErrorContains(t, err, "invalid segment")
 	})
 
 	t.Run("explicit field", func(t *testing.T) {


### PR DESCRIPTION
This functionality will be further enhanced in #80.

Resolves #66