### PR TITLE
didtest: offset persona constants

### DIFF
--- a/did/didtest/crypto.go
+++ b/did/didtest/crypto.go
@@ -28,7 +28,7 @@ type Persona int
 //
 // [table]: https://en.wikipedia.org/wiki/Alice_and_Bob#Cryptographic_systems
 const (
-	PersonaAlice Persona = iota
+	PersonaAlice Persona = iota + 1
 	PersonaBob
 	PersonaCarol
 	PersonaDan


### PR DESCRIPTION
It seems like having a persona with a zero value confuses some static checker into warning against a possible nil pointer deref.

An easy fix is to just not have zero.