### PR TITLE
fix(policy): make 53-bit limits portable across platforms

### DIFF
--- a/pkg/policy/limits/int.go
+++ b/pkg/policy/limits/int.go
@@ -9,9 +9,9 @@ import (
 
 const (
 	// MaxInt53 represents the maximum safe integer in JavaScript (2^53 - 1)
-	MaxInt53 = 9007199254740991
+	MaxInt53 int64 = 9007199254740991
 	// MinInt53 represents the minimum safe integer in JavaScript (-2^53 + 1)
-	MinInt53 = -9007199254740991
+	MinInt53 int64 = -9007199254740991
 )
 
 func ValidateIntegerBoundsIPLD(node ipld.Node) error {

--- a/pkg/policy/literal/literal.go
+++ b/pkg/policy/literal/literal.go
@@ -185,7 +185,7 @@ func anyAssemble(val any) qp.Assemble {
 		return qp.Int(i)
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		u := rv.Uint()
-		if u > limits.MaxInt53 {
+		if u > uint64(limits.MaxInt53) {
 			panic(fmt.Sprintf("unsigned integer %d exceeds safe bounds", u))
 		}
 		return qp.Int(int64(u))

--- a/pkg/policy/selector/parsing.go
+++ b/pkg/policy/selector/parsing.go
@@ -68,7 +68,7 @@ func Parse(str string) (Selector, error) {
 				if err != nil {
 					return nil, newParseError("invalid index", str, col, tok)
 				}
-				if idx > limits.MaxInt53 || idx < limits.MinInt53 {
+				if int64(idx) > limits.MaxInt53 || int64(idx) < limits.MinInt53 {
 					return nil, newParseError(fmt.Sprintf("index %d exceeds safe integer bounds", idx), str, col, tok)
 				}
 				sel = append(sel, segment{str: tok, optional: opt, index: idx})


### PR DESCRIPTION
The `policy` code fails to compile on systems that are NOT 64 bits.  Discovered when compiling to WASM using `TinyGo`.